### PR TITLE
Use tpi for health score

### DIFF
--- a/app/home.tsx
+++ b/app/home.tsx
@@ -139,7 +139,7 @@ const Home = (): React.JSX.Element => {
               const totalSteps = sumValues(stepData.map(s => s.value));
               setSteps(prev => prev + totalSteps);
 
-              const flightsData = newStatData('flights', response.stats);
+              const flightsData = newStatData('flightsClimbed', response.stats);
               const totalFlights = sumValues(flightsData.map(s => s.value));
               setFlights(prev => prev + totalFlights);
 

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -11,8 +11,7 @@ import {
   mostRecentValues,
   newStatData,
   startOfToday,
-  sumValues,
-  totalHealthScore
+  sumValues
 } from '@/components/home/utils';
 import StatCard from '@/components/statCard';
 import { capitalizeFirstLetter } from '@/components/utils';
@@ -144,20 +143,8 @@ const Home = (): React.JSX.Element => {
               const totalFlights = sumValues(flightsData.map(s => s.value));
               setFlights(prev => prev + totalFlights);
 
-              const healthScore = totalHealthScore(
-                averageStat(updatedStats.temperature),
-                averageStat(updatedStats.pressure),
-                averageStat(updatedStats.humidity),
-                averageStat(updatedStats.altitude),
-                averageStat(updatedStats.bpm),
-                steps + totalSteps
-              );
-              const adjustedHealthScore =
-                (healthScore + averageStat(updatedStats.tpi)) / 2;
-
               if (mlInsightsRef.current.length === 0 && user) {
                 const age = getAge(user.birthday);
-                const fitnessLevel = adjustedHealthScore;
                 const insight = await fetchMLInsights(
                   talus.talusId,
                   age,
@@ -165,7 +152,7 @@ const Home = (): React.JSX.Element => {
                   user.height,
                   steps + totalSteps,
                   user.gender,
-                  fitnessLevel
+                  averageStat(updatedStats.tpi)
                 );
                 setMlInsights(insight);
                 mlInsightsRef.current = insight;
@@ -207,20 +194,7 @@ const Home = (): React.JSX.Element => {
           </Text>
         </View>
         {[
-          {
-            label: 'Total Health Score',
-            value:
-              (totalHealthScore(
-                temperatureAvg,
-                pressureAvg,
-                humidityAvg,
-                altitudeAvg,
-                bpmAvg,
-                steps
-              ) +
-                tpiAvg) /
-              2
-          },
+          { label: 'Health Score', value: tpiAvg },
 
           { label: 'Heart Rate (BPM)', value: bpmAvg },
           { label: 'Blood Oxygen (%)', value: spo2Avg },
@@ -229,10 +203,7 @@ const Home = (): React.JSX.Element => {
           { label: 'Cadence (steps/min)', value: cadenceAvg },
           { label: 'Flights Climbed', value: flights },
 
-          {
-            label: 'Avg Force (N)',
-            value: forceAvg * heightMultiplier
-          },
+          { label: 'Avg Force (N)', value: forceAvg * heightMultiplier },
           { label: 'Avg Power (W)', value: powerAvg * weightMultiplier },
 
           { label: 'Temperature (°C)', value: temperatureAvg },

--- a/components/home/types.ts
+++ b/components/home/types.ts
@@ -14,10 +14,10 @@ export type StatName =
   | 'force'
   | 'power'
   | 'spo2'
-  | 'flights'
+  | 'flightsClimbed'
   | 'tpi';
 
-export type RollingStatName = Exclude<StatName, 'steps' | 'flights'>;
+export type RollingStatName = Exclude<StatName, 'steps' | 'flightsClimbed'>;
 
 export type ResponseStat = {
   statName: string;

--- a/components/home/utils.ts
+++ b/components/home/utils.ts
@@ -39,57 +39,6 @@ export const startOfToday = (): Date => {
   return d;
 };
 
-export const totalHealthScore = (
-  temperature: number,
-  pressure: number,
-  humidity: number,
-  altitude: number,
-  bpm: number,
-  steps: number
-): number => {
-  const idealTemperature = 37;
-  const idealPressure = 1013;
-  const idealHumidity = 45;
-  const idealAltitude = 300;
-  const idealBPM = 70;
-  const targetSteps = 10000;
-
-  const temperatureScore = Math.max(
-    0,
-    100 - Math.abs(temperature - idealTemperature) * 2
-  );
-
-  const pressureScore = Math.max(
-    0,
-    100 - Math.abs(pressure - idealPressure) * 0.05
-  );
-
-  const humidityScore = Math.max(
-    0,
-    100 - Math.abs(humidity - idealHumidity) * 1.5
-  );
-
-  const altitudeScore = Math.max(
-    0,
-    100 - Math.abs(altitude - idealAltitude) * 0.01
-  );
-
-  const bpmScore = Math.max(0, 100 - Math.abs(bpm - idealBPM) * 1);
-
-  const stepsScore = Math.min(100, (steps / targetSteps) * 100);
-
-  const totalScore =
-    (temperatureScore +
-      pressureScore +
-      humidityScore +
-      altitudeScore +
-      bpmScore +
-      stepsScore) /
-    6;
-
-  return Math.round(totalScore);
-};
-
 export const getAge = (birthday: Date): number => {
   const today = new Date();
   const birthDate = new Date(birthday);


### PR DESCRIPTION
This pull request primarily refactors how health and fitness statistics are handled and displayed on the home page. The most significant change is the removal of the custom `totalHealthScore` calculation in favor of using the `tpiAvg` value directly for health-related insights and display. Additionally, the naming for flights climbed has been standardized, and related types and logic have been updated accordingly.

**Health Score Calculation and Display:**
- Removed the `totalHealthScore` function and all logic that calculated a composite health score from multiple stats; now, the health score uses only the average TPI (`tpiAvg`) throughout the app. [[1]](diffhunk://#diff-a46df675e415e43bf9f464c854b6b8439cfcfca3e148118f02406cae9c9cd191L42-L92) [[2]](diffhunk://#diff-7a2d2573c55fdb4bf4028f513675b09565954347ddae9cc189bb0693112d3c27L143-R155) [[3]](diffhunk://#diff-7a2d2573c55fdb4bf4028f513675b09565954347ddae9cc189bb0693112d3c27L210-R197)

**Flights Climbed Naming Consistency:**
- Renamed all references from `'flights'` to `'flightsClimbed'` in both the data processing and the `StatName` type definitions to ensure consistency and avoid confusion. [[1]](diffhunk://#diff-7a2d2573c55fdb4bf4028f513675b09565954347ddae9cc189bb0693112d3c27L143-R155) [[2]](diffhunk://#diff-a48f0516fcdb4c5f7386f39401386151bd0cb071196b27d02dfaa7a71392652aL17-R20)

**Type and Utility Updates:**
- Updated the `RollingStatName` type to exclude `'flightsClimbed'` instead of `'flights'` for consistency with the new naming.

**Minor Code Cleanups:**
- Cleaned up the stat display list and related code for improved readability and to reflect the above changes.